### PR TITLE
ポットゲージの下から飛び出すバグ修正

### DIFF
--- a/Magic/Assets/Work/Tachihara/Scripts/PotGaugeController.cs
+++ b/Magic/Assets/Work/Tachihara/Scripts/PotGaugeController.cs
@@ -9,8 +9,8 @@ public class PotGaugeController : MonoBehaviour {
   float SCALE_Y = 0.0f;
 
   TuboInDestroy tubo_ = null;
-  int current_count_ = 0;       // 現在のカウント
-  int accumlation_count_ = 0;   // 累積カウント
+  int current_count_ = 0;   // 現在のカウント
+  int last_count_ = 0;      // 累積カウント
 
   SpriteRenderer effect_ = null;
   Color ALPHA = new Color(1, 1, 1, 0);
@@ -27,22 +27,39 @@ public class PotGaugeController : MonoBehaviour {
   }
 
   void Update() {
-    current_count_ = tubo_.GetKudamonCount() - accumlation_count_;
-    
+    if (IsCountMax()) {
+      effect_.transform.Rotate(new Vector3(0, 0, -Time.deltaTime * 60));
+    }
+
+    // 計算前の値を取得、ナベの中身が増えてなければ処理をスキップ
+    {
+      var prev = current_count_;
+      CountUp();
+      if (prev == current_count_) { return; }
+    }
+    if (current_count_ > 10) { current_count_ = 10; }
+
     var ratio = current_count_ * 0.1f;
     var scale = new Vector3(SCALE_X, SCALE_Y * ratio, 1.0f);
     bar_.localScale = scale;
 
-    var maximum = (current_count_ == 10);
-
-    var set_color = (maximum ? Color.white : ALPHA);
-    if (effect_.color != set_color) { effect_.color = set_color; }
-
-    if (!maximum) { return; }
-    effect_.transform.Rotate(new Vector3(0, 0, -Time.deltaTime * 60));
+    if (IsCountMax() && effect_.color != Color.white) {
+      effect_.color = Color.white;
+    }
   }
 
   public void GaugeReset() {
-    accumlation_count_ += current_count_;
+    // 正しく初期化できるようにカウントを再計算する
+    CountUp();
+    last_count_ += current_count_;
+
+    // 色を戻す
+    effect_.color = ALPHA;
   }
+
+  void CountUp() {
+    current_count_ = tubo_.GetKudamonCount() - last_count_;
+  }
+
+  bool IsCountMax() { return current_count_ == 10; }
 }

--- a/Magic/Assets/Work/Tachihara/Scripts/PotGaugeController.cs
+++ b/Magic/Assets/Work/Tachihara/Scripts/PotGaugeController.cs
@@ -28,8 +28,7 @@ public class PotGaugeController : MonoBehaviour {
 
   void Update() {
     current_count_ = tubo_.GetKudamonCount() - accumlation_count_;
-
-    if (current_count_ > 10) { current_count_ = 10; }
+    
     var ratio = current_count_ * 0.1f;
     var scale = new Vector3(SCALE_X, SCALE_Y * ratio, 1.0f);
     bar_.localScale = scale;


### PR DESCRIPTION
### 原因

ナベのスクリプトから取り出す値を初期化する処理が入っておらず、
常に増え続ける状態だったため、
UI 側で差分を計算、管理する方法にしていた。

差分の計算は動作していたが、計算後の値を元に戻さないまま
使っていたのが原因だった。
### 解決方法

・上限の範囲チェックによるゲージ飛び出し防止は、やっぱり必要。
・ゲージを初期化するときに、カウントを再計算してから
　次回の初期値として管理する方法に変更。
